### PR TITLE
Support both pre- and post- 4.6 callback methods

### DIFF
--- a/civi-wp-ms-users.php
+++ b/civi-wp-ms-users.php
@@ -554,9 +554,23 @@ class Civi_WP_Member_Sync_Users {
 	 */
 	private function remove_filters() {
 
-		// remove Civi plugin filters
-		remove_action( 'user_register', array( civi_wp()->users, 'update_user' ) );
-		remove_action( 'profile_update', array( civi_wp()->users, 'update_user' ) );
+		// get Civi instance
+		$civi = civi_wp();
+
+		// do we have the old-style plugin structure?
+		if ( method_exists( $civi, 'update_user' ) ) {
+
+			// remove previous Civi plugin filters
+			remove_action( 'user_register', array( civi_wp(), 'update_user' ) );
+			remove_action( 'profile_update', array( civi_wp(), 'update_user' ) );
+
+		} else {
+
+			// remove current Civi plugin filters
+			remove_action( 'user_register', array( civi_wp()->users, 'update_user' ) );
+			remove_action( 'profile_update', array( civi_wp()->users, 'update_user' ) );
+
+		}
 
 		// remove CiviCRM WordPress Profile Sync filters
 		global $civicrm_wp_profile_sync;
@@ -581,9 +595,23 @@ class Civi_WP_Member_Sync_Users {
 	 */
 	private function add_filters() {
 
-		// re-add Civi plugin filters
-		add_action( 'user_register', array( civi_wp()->users, 'update_user' ) );
-		add_action( 'profile_update', array( civi_wp()->users, 'update_user' ) );
+		// get Civi instance
+		$civi = civi_wp();
+
+		// do we have the old-style plugin structure?
+		if ( method_exists( $civi, 'update_user' ) ) {
+
+			// re-add previous Civi plugin filters
+			add_action( 'user_register', array( civi_wp(), 'update_user' ) );
+			add_action( 'profile_update', array( civi_wp(), 'update_user' ) );
+
+		} else {
+
+			// re-add current Civi plugin filters
+			add_action( 'user_register', array( civi_wp()->users, 'update_user' ) );
+			add_action( 'profile_update', array( civi_wp()->users, 'update_user' ) );
+
+		}
 
 		// re-add CiviCRM WordPress Profile Sync filters
 		global $civicrm_wp_profile_sync;

--- a/civi-wp-ms-users.php
+++ b/civi-wp-ms-users.php
@@ -555,8 +555,8 @@ class Civi_WP_Member_Sync_Users {
 	private function remove_filters() {
 
 		// remove Civi plugin filters
-		remove_action( 'user_register', array( civi_wp(), 'update_user' ) );
-		remove_action( 'profile_update', array( civi_wp(), 'update_user' ) );
+		remove_action( 'user_register', array( civi_wp()->users, 'update_user' ) );
+		remove_action( 'profile_update', array( civi_wp()->users, 'update_user' ) );
 
 		// remove CiviCRM WordPress Profile Sync filters
 		global $civicrm_wp_profile_sync;
@@ -582,8 +582,8 @@ class Civi_WP_Member_Sync_Users {
 	private function add_filters() {
 
 		// re-add Civi plugin filters
-		add_action( 'user_register', array( civi_wp(), 'update_user' ) );
-		add_action( 'profile_update', array( civi_wp(), 'update_user' ) );
+		add_action( 'user_register', array( civi_wp()->users, 'update_user' ) );
+		add_action( 'profile_update', array( civi_wp()->users, 'update_user' ) );
 
 		// re-add CiviCRM WordPress Profile Sync filters
 		global $civicrm_wp_profile_sync;


### PR DESCRIPTION
Prior to Civi 4.6, the user callback methods were located in `class CiviCRM_For_WordPress`. They are now located in `class CiviCRM_For_WordPress_Users`. These commits support both variants in case people are using the with versions of Civi prior to 4.6.