### PR TITLE
apply new username filter for dry run, too.

### DIFF
--- a/includes/civi-wp-ms-members.php
+++ b/includes/civi-wp-ms-members.php
@@ -441,8 +441,9 @@ class Civi_WP_Member_Sync_Members {
 
 		// Create username from display name.
 		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		$user_name = $this->plugin->users->unique_username( $user_name, $civi_contact );
 		$user_name = apply_filters( 'civi_wp_member_sync_new_username', $user_name, $civi_contact );
-		$user->user_login = $this->plugin->users->unique_username( $user_name, $civi_contact );
+		$user->user_login = $user_name
 
 		// Add Display Name and First & Last Names.
 		$user->display_name = $civi_contact['display_name'];

--- a/includes/civi-wp-ms-members.php
+++ b/includes/civi-wp-ms-members.php
@@ -441,6 +441,7 @@ class Civi_WP_Member_Sync_Members {
 
 		// Create username from display name.
 		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		$user_name = apply_filters( 'civi_wp_member_sync_new_username', $user_name, $civi_contact );
 		$user->user_login = $this->plugin->users->unique_username( $user_name, $civi_contact );
 
 		// Add Display Name and First & Last Names.

--- a/includes/civi-wp-ms-members.php
+++ b/includes/civi-wp-ms-members.php
@@ -443,7 +443,7 @@ class Civi_WP_Member_Sync_Members {
 		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
 		$user_name = $this->plugin->users->unique_username( $user_name, $civi_contact );
 		$user_name = apply_filters( 'civi_wp_member_sync_new_username', $user_name, $civi_contact );
-		$user->user_login = $user_name
+		$user->user_login = $user_name;
 
 		// Add Display Name and First & Last Names.
 		$user->display_name = $civi_contact['display_name'];


### PR DESCRIPTION
Allows _dry run_ option for _Manual Synchronization_ to show the username that might be used when the `civi_wp_member_sync_new_username` filter is defined.
Addresses #44.