### PR TITLE
Add hard-coded  Domain ID to ufmatch_create civi-wp-ms-users.php

### DIFF
--- a/includes/civi-wp-ms-users.php
+++ b/includes/civi-wp-ms-users.php
@@ -767,7 +767,7 @@ class Civi_WP_Member_Sync_Users {
 
 			// Create a UF Match record if the User was successfully created.
 			if ( ! is_wp_error( $user_id ) && isset( $civi_contact['contact_id'] ) ) {
-				$this->ufmatch_create( $civi_contact['contact_id'], $user_id, $civi_contact['email'] );
+				$this->ufmatch_create(1, $civi_contact['contact_id'], $user_id, $civi_contact['email'] );
 			}
 
 			/**


### PR DESCRIPTION
Found in php error logs:  DB Constraint Violation - domain_id should possibly be marked as mandatory for UFMatch,create API. [backtrace] => #0 /wp-content/plugins/civicrm-wp-member-sync/includes/civi-wp-ms-users.php(770): Civi_WP_Member_Sync_Users->ufmatch_create(