### PR TITLE
Prefer the CiviCRM nickname field as a username

### DIFF
--- a/includes/civi-wp-ms-members.php
+++ b/includes/civi-wp-ms-members.php
@@ -471,7 +471,12 @@ class Civi_WP_Member_Sync_Members {
 		$user->ID = PHP_INT_MAX;
 
 		// Create username from display name.
-		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		if ( ! empty( $civi_contact['nick_name'] ) )
+		{
+			$user_name = sanitize_user( $civi_contact['nick_name'] );
+		} else {
+			$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		}
 		$user_name = $this->plugin->users->unique_username( $user_name, $civi_contact );
 
 		/**

--- a/includes/civi-wp-ms-users.php
+++ b/includes/civi-wp-ms-users.php
@@ -728,7 +728,12 @@ class Civi_WP_Member_Sync_Users {
 		$new_user = false;
 
 		// Create username from display name.
-		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		if ( ! empty( $civi_contact['nick_name'] ) )
+		{
+			$user_name = sanitize_user( $civi_contact['nick_name'] );
+		} else {
+			$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		}
 
 		// Ensure username is unique.
 		$user_name = $this->unique_username( $user_name, $civi_contact );


### PR DESCRIPTION
CiviCRM does have a standard field "nick_name" field in user contacts, which should be used as an account name when synchronizing a user to WordPress.

This patch prefers the nick name, if set, over the "display_name" field which is the user's full name.

Moreover, don't over-sanitize usernames if the nick_name field is used (e.g., this would allow white space in a user name, if the user desires so, whereas I think for the "display_name" this is fine). See also https://developer.wordpress.org/reference/functions/sanitize_user/.

P.S. I'm sorry, I don't really know any PHP so I barely know what I'm doing. I hope this PR don't messes to much with your code style. 