### PR TITLE
Feature/ add Username Source Field setting (display_name / nick_name)

### DIFF
--- a/assets/templates/settings.php
+++ b/assets/templates/settings.php
@@ -189,7 +189,7 @@ defined( 'ABSPATH' ) || exit;
 					<input type="checkbox" class="settings-checkbox" name="civi_wp_member_sync_settings_schedule" id="civi_wp_member_sync_settings_schedule" value="1"<?php checked( 1, $schedule ); ?> />
 					<label class="civi_wp_member_sync_settings_label" for="civi_wp_member_sync_settings_schedule"><?php esc_html_e( 'Synchronize using a WordPress recurring schedule. This action is performed on all Users and Contacts.', 'civicrm-wp-member-sync' ); ?></label>
 					<p class="description"><?php esc_html_e( 'This action can be very processor intensive if you have a lot of Users and Contacts. It is not recommended to have this switched on unless you have a good reason for doing so.', 'civicrm-wp-member-sync' ); ?></p>
-					<div class="notice notice-warning inline"><p><?php esc_html_e( 'Please not that this action will be removed in the next major release.', 'civicrm-wp-member-sync' ); ?></p></div>
+					<div class="notice notice-warning inline"><p><?php esc_html_e( 'Please not that this action will be replaced by a WP-CLI command in the next major release.', 'civicrm-wp-member-sync' ); ?></p></div>
 				</td>
 			</tr>
 

--- a/assets/templates/settings.php
+++ b/assets/templates/settings.php
@@ -189,7 +189,7 @@ defined( 'ABSPATH' ) || exit;
 					<input type="checkbox" class="settings-checkbox" name="civi_wp_member_sync_settings_schedule" id="civi_wp_member_sync_settings_schedule" value="1"<?php checked( 1, $schedule ); ?> />
 					<label class="civi_wp_member_sync_settings_label" for="civi_wp_member_sync_settings_schedule"><?php esc_html_e( 'Synchronize using a WordPress recurring schedule. This action is performed on all Users and Contacts.', 'civicrm-wp-member-sync' ); ?></label>
 					<p class="description"><?php esc_html_e( 'This action can be very processor intensive if you have a lot of Users and Contacts. It is not recommended to have this switched on unless you have a good reason for doing so.', 'civicrm-wp-member-sync' ); ?></p>
-					<div class="notice notice-warning inline"><p><?php esc_html_e( 'Please not that this action will be replaced by a WP-CLI command in the next major release.', 'civicrm-wp-member-sync' ); ?></p></div>
+					<div class="notice notice-warning inline"><p><?php esc_html_e( 'Please not that this action will be removed in the next major release.', 'civicrm-wp-member-sync' ); ?></p></div>
 				</td>
 			</tr>
 
@@ -222,6 +222,19 @@ defined( 'ABSPATH' ) || exit;
 					<input type="checkbox" class="settings-checkbox" name="civi_wp_member_sync_settings_types" id="civi_wp_member_sync_settings_types" value="1"<?php checked( 1, $types ); ?> />
 					<label class="civi_wp_member_sync_settings_label" for="civi_wp_member_sync_settings_types"><?php esc_html_e( 'Synchronize Individuals only.', 'civicrm-wp-member-sync' ); ?></label>
 					<p class="description"><?php esc_html_e( 'In versions of CiviCRM Member Sync prior to 0.3.5, all CiviCRM Memberships were synchronized to WordPress Users. This meant that Organisations and Households also had corresponding WordPress Users. If you want to restrict syncing to Individuals only, then check the box below.', 'civicrm-wp-member-sync' ); ?></p>
+				</td>
+			</tr>
+
+			<tr>
+				<th scope="row">
+					<label class="civi_wp_member_sync_settings_label" for="civi_wp_member_sync_settings_username_field"><?php esc_html_e( 'Username Source Field', 'civicrm-wp-member-sync' ); ?></label>
+				</th>
+				<td>
+					<select class="settings-select" name="civi_wp_member_sync_settings_username_field" id="civi_wp_member_sync_settings_username_field">
+						<option value="display_name"<?php selected( 'display_name', $username_field ); ?>><?php esc_html_e( 'Display Name', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="nick_name"<?php selected( 'nick_name', $username_field ); ?>><?php esc_html_e( 'Nickname', 'civicrm-wp-member-sync' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Choose which CiviCRM Contact field is used to generate the WordPress username when a new User is created. If "Nickname" is selected but the Contact has no nickname, Display Name is used as a fallback.', 'civicrm-wp-member-sync' ); ?></p>
 				</td>
 			</tr>
 

--- a/includes/civi-wp-ms-admin.php
+++ b/includes/civi-wp-ms-admin.php
@@ -1012,6 +1012,9 @@ class Civi_WP_Member_Sync_Admin {
 		// Get our types setting.
 		$types = (int) $this->setting_get( 'types' );
 
+		// Get username field setting.
+		$username_field = $this->setting_get_username_field();
+
 		// Check if CiviCRM Admin Utilities has been installed.
 		$cau_present = $this->cau_activated();
 
@@ -1565,6 +1568,9 @@ class Civi_WP_Member_Sync_Admin {
 		// Sync only the "Individual" Contact Type by default.
 		$settings['types'] = 1;
 
+		// Use display_name as the username source by default.
+		$settings['username_field'] = 'display_name';
+
 		/**
 		 * Allows the plugin settings to be filtered.
 		 *
@@ -1662,6 +1668,14 @@ class Civi_WP_Member_Sync_Admin {
 			$settings_types = (int) wp_unslash( $settings_types_raw );
 		}
 		$this->setting_set( 'types', ( $settings_types ? 1 : 0 ) );
+
+		// CiviCRM Contact field used as WordPress username source.
+		$settings_username_field     = 'display_name';
+		$settings_username_field_raw = filter_input( INPUT_POST, 'civi_wp_member_sync_settings_username_field' );
+		if ( ! empty( $settings_username_field_raw ) ) {
+			$settings_username_field = trim( wp_unslash( $settings_username_field_raw ) );
+		}
+		$this->setting_set( 'username_field', ( 'nick_name' === $settings_username_field ) ? 'nick_name' : 'display_name' );
 
 		// Save settings.
 		$this->settings_save();
@@ -1784,6 +1798,22 @@ class Civi_WP_Member_Sync_Admin {
 
 		// --<
 		return $count;
+
+	}
+
+	// -----------------------------------------------------------------------------------
+
+	/**
+	 * Get the CiviCRM Contact field to use as the WordPress username source.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @return string Either 'display_name' or 'nick_name'.
+	 */
+	public function setting_get_username_field() {
+
+		$field = $this->setting_get( 'username_field', 'display_name' );
+		return ( 'nick_name' === $field ) ? 'nick_name' : 'display_name';
 
 	}
 

--- a/includes/civi-wp-ms-members.php
+++ b/includes/civi-wp-ms-members.php
@@ -470,8 +470,12 @@ class Civi_WP_Member_Sync_Members {
 		$user     = new WP_User();
 		$user->ID = PHP_INT_MAX;
 
-		// Create username from display name.
-		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		// Determine the source field for the username per plugin settings.
+		$username_field  = $this->plugin->admin->setting_get_username_field();
+		$name_source_sim = ( 'nick_name' === $username_field && ! empty( $civi_contact['nick_name'] ) )
+			? $civi_contact['nick_name']
+			: $civi_contact['display_name'];
+		$user_name = sanitize_title( sanitize_user( $name_source_sim ) );
 		$user_name = $this->plugin->users->unique_username( $user_name, $civi_contact );
 
 		/**

--- a/includes/civi-wp-ms-users.php
+++ b/includes/civi-wp-ms-users.php
@@ -734,6 +734,11 @@ class Civi_WP_Member_Sync_Users {
 			: $civi_contact['display_name'];
 		$user_name = sanitize_title( sanitize_user( $name_source ) );
 
+		// WordPress wp_users.user_login is VARCHAR(60); truncate to avoid insert failure.
+		if ( strlen( $user_name ) > 60 ) {
+			$user_name = rtrim( substr( $user_name, 0, 60 ), '-' );
+		}
+
 		// Ensure username is unique.
 		$user_name = $this->unique_username( $user_name, $civi_contact );
 

--- a/includes/civi-wp-ms-users.php
+++ b/includes/civi-wp-ms-users.php
@@ -727,8 +727,12 @@ class Civi_WP_Member_Sync_Users {
 		// Assume it's not a new User.
 		$new_user = false;
 
-		// Create username from display name.
-		$user_name = sanitize_title( sanitize_user( $civi_contact['display_name'] ) );
+		// Determine the source field for the username per plugin settings.
+		$username_field = $this->plugin->admin->setting_get_username_field();
+		$name_source    = ( 'nick_name' === $username_field && ! empty( $civi_contact['nick_name'] ) )
+			? $civi_contact['nick_name']
+			: $civi_contact['display_name'];
+		$user_name = sanitize_title( sanitize_user( $name_source ) );
 
 		// Ensure username is unique.
 		$user_name = $this->unique_username( $user_name, $civi_contact );
@@ -856,10 +860,16 @@ class Civi_WP_Member_Sync_Users {
 		$count       = 1;
 		$user_exists = 1;
 
+		// Determine the source field for the username per plugin settings.
+		$username_field  = $this->plugin->admin->setting_get_username_field();
+		$name_source_uniq = ( 'nick_name' === $username_field && ! empty( $civi_contact['nick_name'] ) )
+			? $civi_contact['nick_name']
+			: $civi_contact['display_name'];
+
 		do {
 
 			// Construct new username with numeric suffix.
-			$new_username = sanitize_title( sanitize_user( $civi_contact['display_name'] . ' ' . $count ) );
+			$new_username = sanitize_title( sanitize_user( $name_source_uniq . ' ' . $count ) );
 
 			// How did we do?
 			$user_exists = username_exists( $new_username );


### PR DESCRIPTION
Adds a setting to choose which CiviCRM Contact field is used to generate the WordPress username when a new User is created: display_name (default, for compatibility) or nick_name. Falls back to display_name when nick_name is empty.
Useful for organizations with long names that want shorter, more practical usernames