### PR TITLE
add Membership Ownership filter to Association Rules

### DIFF
--- a/assets/templates/rule-cap-add.php
+++ b/assets/templates/rule-cap-add.php
@@ -108,6 +108,20 @@ defined( 'ABSPATH' ) || exit;
 
 			?>
 
+			<tr>
+				<th scope="row">
+					<label class="ownership_filter_label" for="ownership_filter"><?php esc_html_e( 'Membership Ownership', 'civicrm-wp-member-sync' ); ?></label>
+				</th>
+				<td>
+					<select name="ownership_filter" id="ownership_filter">
+						<option value="all"><?php esc_html_e( 'All members (include members by relationship)', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="primary"><?php esc_html_e( 'Only primary members', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="relationship"><?php esc_html_e( 'Only members by relationship', 'civicrm-wp-member-sync' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Restrict this rule to primary Memberships, to Memberships inherited via a CiviCRM relationship, or leave as "All members" to apply to both (default).', 'civicrm-wp-member-sync' ); ?></p>
+				</td>
+			</tr>
+
 		</table>
 
 		<input type="hidden" id="civi_wp_member_sync_rules_mode" name="civi_wp_member_sync_rules_mode" value="add" />

--- a/assets/templates/rule-cap-edit.php
+++ b/assets/templates/rule-cap-edit.php
@@ -110,6 +110,20 @@ defined( 'ABSPATH' ) || exit;
 
 			?>
 
+			<tr>
+				<th scope="row">
+					<label class="ownership_filter_label" for="ownership_filter"><?php esc_html_e( 'Membership Ownership', 'civicrm-wp-member-sync' ); ?></label>
+				</th>
+				<td>
+					<select name="ownership_filter" id="ownership_filter">
+						<option value="all"<?php selected( 'all', $ownership_filter ); ?>><?php esc_html_e( 'All members (include members by relationship)', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="primary"<?php selected( 'primary', $ownership_filter ); ?>><?php esc_html_e( 'Only primary members', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="relationship"<?php selected( 'relationship', $ownership_filter ); ?>><?php esc_html_e( 'Only members by relationship', 'civicrm-wp-member-sync' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Restrict this rule to primary Memberships, to Memberships inherited via a CiviCRM relationship, or leave as "All members" to apply to both (default).', 'civicrm-wp-member-sync' ); ?></p>
+				</td>
+			</tr>
+
 		</table>
 
 		<input type="hidden" id="civi_wp_member_sync_rules_mode" name="civi_wp_member_sync_rules_mode" value="edit" />

--- a/assets/templates/rule-role-add.php
+++ b/assets/templates/rule-role-add.php
@@ -132,6 +132,20 @@ defined( 'ABSPATH' ) || exit;
 
 			?>
 
+			<tr>
+				<th scope="row">
+					<label class="ownership_filter_label" for="ownership_filter"><?php esc_html_e( 'Membership Ownership', 'civicrm-wp-member-sync' ); ?></label>
+				</th>
+				<td>
+					<select name="ownership_filter" id="ownership_filter">
+						<option value="all"><?php esc_html_e( 'All members (include members by relationship)', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="primary"><?php esc_html_e( 'Only primary members', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="relationship"><?php esc_html_e( 'Only members by relationship', 'civicrm-wp-member-sync' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Restrict this rule to primary Memberships, to Memberships inherited via a CiviCRM relationship, or leave as "All members" to apply to both (default).', 'civicrm-wp-member-sync' ); ?></p>
+				</td>
+			</tr>
+
 		</table>
 
 		<input type="hidden" id="civi_wp_member_sync_rules_mode" name="civi_wp_member_sync_rules_mode" value="add" />

--- a/assets/templates/rule-role-edit.php
+++ b/assets/templates/rule-role-edit.php
@@ -132,6 +132,20 @@ defined( 'ABSPATH' ) || exit;
 
 			?>
 
+			<tr>
+				<th scope="row">
+					<label class="ownership_filter_label" for="ownership_filter"><?php esc_html_e( 'Membership Ownership', 'civicrm-wp-member-sync' ); ?></label>
+				</th>
+				<td>
+					<select name="ownership_filter" id="ownership_filter">
+						<option value="all"<?php selected( 'all', $ownership_filter ); ?>><?php esc_html_e( 'All members (include members by relationship)', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="primary"<?php selected( 'primary', $ownership_filter ); ?>><?php esc_html_e( 'Only primary members', 'civicrm-wp-member-sync' ); ?></option>
+						<option value="relationship"<?php selected( 'relationship', $ownership_filter ); ?>><?php esc_html_e( 'Only members by relationship', 'civicrm-wp-member-sync' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Restrict this rule to primary Memberships, to Memberships inherited via a CiviCRM relationship, or leave as "All members" to apply to both (default).', 'civicrm-wp-member-sync' ); ?></p>
+				</td>
+			</tr>
+
 		</table>
 
 		<input type="hidden" id="civi_wp_member_sync_rules_mode" name="civi_wp_member_sync_rules_mode" value="edit" />

--- a/includes/civi-wp-ms-admin.php
+++ b/includes/civi-wp-ms-admin.php
@@ -1283,8 +1283,9 @@ class Civi_WP_Member_Sync_Admin {
 		$selected_rule = $this->rule_get_by_type( $civi_member_type_id, $method );
 
 		// Set vars for populating form.
-		$current_rule = $selected_rule['current_rule'];
-		$expiry_rule  = $selected_rule['expiry_rule'];
+		$current_rule     = $selected_rule['current_rule'];
+		$expiry_rule      = $selected_rule['expiry_rule'];
+		$ownership_filter = isset( $selected_rule['ownership_filter'] ) ? $selected_rule['ownership_filter'] : 'all';
 
 		// Get rules.
 		$rules = $this->rules_get_by_method( $method );
@@ -2067,6 +2068,16 @@ class Civi_WP_Member_Sync_Admin {
 			$this->errors[] = 'expire-status';
 		}
 
+		// Check and sanitise Membership Ownership filter.
+		$ownership_filter     = 'all';
+		$ownership_filter_raw = filter_input( INPUT_POST, 'ownership_filter' );
+		if ( ! empty( $ownership_filter_raw ) ) {
+			$ownership_filter_raw = trim( wp_unslash( $ownership_filter_raw ) );
+			if ( in_array( $ownership_filter_raw, [ 'primary', 'relationship' ], true ) ) {
+				$ownership_filter = $ownership_filter_raw;
+			}
+		}
+
 		// Init current-expire check (will end up true if there's a clash).
 		$current_expire_clash = false;
 
@@ -2122,10 +2133,11 @@ class Civi_WP_Member_Sync_Admin {
 
 						// Combine rule data into array.
 						$rule_data = [
-							'current_rule'    => $current_rule,
-							'current_wp_role' => $current_wp_role,
-							'expiry_rule'     => $expiry_rule,
-							'expired_wp_role' => $expired_wp_role,
+							'current_rule'     => $current_rule,
+							'current_wp_role'  => $current_wp_role,
+							'expiry_rule'      => $expiry_rule,
+							'expired_wp_role'  => $expired_wp_role,
+							'ownership_filter' => $ownership_filter,
 						];
 
 						// Get formatted array.
@@ -2141,6 +2153,7 @@ class Civi_WP_Member_Sync_Admin {
 							'current_rule'        => $current_rule,
 							'expiry_rule'         => $expiry_rule,
 							'civi_member_type_id' => $civi_member_type_id,
+							'ownership_filter'    => $ownership_filter,
 						];
 
 						// Get formatted array.
@@ -2160,10 +2173,11 @@ class Civi_WP_Member_Sync_Admin {
 
 					// Combine rule data into array.
 					$rule_data = [
-						'current_rule'    => $current_rule,
-						'current_wp_role' => $current_wp_role,
-						'expiry_rule'     => $expiry_rule,
-						'expired_wp_role' => $expired_wp_role,
+						'current_rule'     => $current_rule,
+						'current_wp_role'  => $current_wp_role,
+						'expiry_rule'      => $expiry_rule,
+						'expired_wp_role'  => $expired_wp_role,
+						'ownership_filter' => $ownership_filter,
 					];
 
 					// Get formatted array.
@@ -2179,6 +2193,7 @@ class Civi_WP_Member_Sync_Admin {
 						'current_rule'        => $current_rule,
 						'expiry_rule'         => $expiry_rule,
 						'civi_member_type_id' => $civi_member_type_id,
+						'ownership_filter'    => $ownership_filter,
 					];
 
 					// Get formatted array.
@@ -2229,19 +2244,21 @@ class Civi_WP_Member_Sync_Admin {
 
 			// Construct Role rule.
 			$rule = [
-				'current_rule'    => $params['current_rule'],
-				'current_wp_role' => $params['current_wp_role'],
-				'expiry_rule'     => $params['expiry_rule'],
-				'expired_wp_role' => $params['expired_wp_role'],
+				'current_rule'     => $params['current_rule'],
+				'current_wp_role'  => $params['current_wp_role'],
+				'expiry_rule'      => $params['expiry_rule'],
+				'expired_wp_role'  => $params['expired_wp_role'],
+				'ownership_filter' => $params['ownership_filter'],
 			];
 
 		} else {
 
 			// Construct Capability rule.
 			$rule = [
-				'current_rule' => $params['current_rule'],
-				'expiry_rule'  => $params['expiry_rule'],
-				'capability'   => CIVI_WP_MEMBER_SYNC_CAP_PREFIX . $params['civi_member_type_id'],
+				'current_rule'     => $params['current_rule'],
+				'expiry_rule'      => $params['expiry_rule'],
+				'capability'       => CIVI_WP_MEMBER_SYNC_CAP_PREFIX . $params['civi_member_type_id'],
+				'ownership_filter' => $params['ownership_filter'],
 			];
 
 		}
@@ -2396,6 +2413,38 @@ class Civi_WP_Member_Sync_Admin {
 	}
 
 	/**
+	 * Check whether a Membership matches an Association Rule's ownership filter.
+	 *
+	 * The "ownership_filter" setting restricts a rule to "all" Memberships,
+	 * "primary" Memberships only (owner_membership_id is empty) or
+	 * "relationship" Memberships only (owner_membership_id is set, i.e. the
+	 * Membership was inherited via a CiviCRM relationship). Rules saved before
+	 * this filter existed default to "all" for backwards compatibility.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array $association_rule The Association Rule.
+	 * @param array $membership The CiviCRM Membership data.
+	 * @return bool True if the Membership matches the filter, false otherwise.
+	 */
+	public function rule_ownership_matches( $association_rule, $membership ) {
+
+		$ownership_filter = isset( $association_rule['ownership_filter'] ) ? $association_rule['ownership_filter'] : 'all';
+
+		if ( 'primary' === $ownership_filter ) {
+			return empty( $membership['owner_membership_id'] );
+		}
+
+		if ( 'relationship' === $ownership_filter ) {
+			return ! empty( $membership['owner_membership_id'] );
+		}
+
+		// 'all' or any unrecognised value.
+		return true;
+
+	}
+
+	/**
 	 * Check if there is at least one rule applied to a set of Memberships.
 	 *
 	 * The reason for this method is, as @andymyersau points out, that Users
@@ -2445,6 +2494,11 @@ class Civi_WP_Member_Sync_Admin {
 
 			// Continue with next Membership if we have an error or no rule exists.
 			if ( false === $association_rule ) {
+				continue;
+			}
+
+			// Continue with next Membership if the ownership filter doesn't match.
+			if ( ! $this->rule_ownership_matches( $association_rule, $membership ) ) {
 				continue;
 			}
 
@@ -2553,6 +2607,11 @@ class Civi_WP_Member_Sync_Admin {
 
 			// Continue with next rule if we have an error of some kind.
 			if ( false === $association_rule ) {
+				continue;
+			}
+
+			// Continue with next Membership if the ownership filter doesn't match.
+			if ( ! $this->rule_ownership_matches( $association_rule, $membership ) ) {
 				continue;
 			}
 
@@ -2792,6 +2851,11 @@ class Civi_WP_Member_Sync_Admin {
 
 			// Continue with next rule if we have an error of some kind.
 			if ( false === $association_rule ) {
+				continue;
+			}
+
+			// Continue with next Membership if the ownership filter doesn't match.
+			if ( ! $this->rule_ownership_matches( $association_rule, $membership ) ) {
 				continue;
 			}
 

--- a/includes/civi-wp-ms-members.php
+++ b/includes/civi-wp-ms-members.php
@@ -920,6 +920,7 @@ class Civi_WP_Member_Sync_Members {
 				'is_test',
 				'is_pay_later',
 				'status_id.is_current_member',
+				'owner_membership_id',
 			],
 		];
 


### PR DESCRIPTION
CiviCRM automatically creates "child" Memberships with the owner_membership_id field set when a Membership Type is configured to inherit via a relationship. Until now, Association Rules applied identically to both primary and inherited Memberships, with no way to distinguish between them.

This PR adds a "Membership Ownership" dropdown to each Association Rule with three options:

- All members (current behaviour, no filtering)
- Only primary members (owner_membership_id is null)
- Only members by relationship (owner_membership_id is not null)

The filter is applied consistently across rule_exists(), rule_apply() and rule_simulate(), so it behaves the same in both Dry Run and real sync. Rules saved before this change default to "All members" for backwards compatibility.

Tested on a live install with real inherited Memberships (Dry Run and real execution), confirming the filter correctly includes/excludes Memberships based on owner_membership_id and that the resulting WordPress User/role is created as expected.